### PR TITLE
feat/add-composite-key-findByPk-support

### DIFF
--- a/packages/core/src/model.js
+++ b/packages/core/src/model.js
@@ -1402,8 +1402,8 @@ ${associationOwner._getAssociationDebugList()}`);
    * Returns the model with the matching primary key.
    * If not found, returns null or throws an error if {@link FindOptions.rejectOnEmpty} is set.
    *
-   * @param  {number|bigint|string|Buffer}      param The value of the desired instance's primary key.
-   * @param  {object}                           [options] find options
+   * @param  {number|bigint|string|Buffer|object}      param The value of the desired instance's primary key.
+   * @param  {object}                                  [options] find options
    * @returns {Promise<Model|null>}
    */
   static async findByPk(param, options) {
@@ -1419,6 +1419,23 @@ ${associationOwner._getAssociationDebugList()}`);
         // TODO: support composite primary keys
         [this.primaryKeyAttribute]: param,
       };
+    } else if (typeof param === 'object') {
+      // composite primary key support
+      options.where = Object.values(this.primaryKeys).reduce((where, pkMetadata) => {
+        if (param[pkMetadata.columnName] === undefined) {
+          return where;
+        }
+
+        return {
+          ...where,
+          [pkMetadata.columnName]: param[pkMetadata.columnName],
+        };
+      }, {});
+
+      if (Object.keys(this.primaryKeys).length !== Object.keys(options.where).length) {
+        throw new TypeError('Primary key mismatch. Please pass all primary keys');
+      }
+
     } else {
       throw new TypeError(`Argument passed to findByPk is invalid: ${param}`);
     }

--- a/packages/core/src/model.js
+++ b/packages/core/src/model.js
@@ -1421,16 +1421,12 @@ ${associationOwner._getAssociationDebugList()}`);
       };
     } else if (typeof param === 'object') {
       // composite primary key support
-      options.where = Object.values(this.primaryKeys).reduce((where, pkMetadata) => {
-        if (param[pkMetadata.columnName] === undefined) {
-          return where;
+      options.where = {};
+      for (const pkMetadata of Object.values(this.primaryKeys)) {
+        if (param[pkMetadata.columnName] !== undefined) {
+          options.where[pkMetadata.columnName] = param[pkMetadata.columnName];
         }
-
-        return {
-          ...where,
-          [pkMetadata.columnName]: param[pkMetadata.columnName],
-        };
-      }, {});
+      }
 
       if (Object.keys(this.primaryKeys).length !== Object.keys(options.where).length) {
         throw new TypeError('Primary key mismatch. Please pass all primary keys');

--- a/packages/core/test/unit/model/find-by-pk.test.js
+++ b/packages/core/test/unit/model/find-by-pk.test.js
@@ -5,7 +5,7 @@ const Support = require('../../support');
 const current = Support.sequelize;
 const sinon = require('sinon');
 const { DataTypes, Sequelize } = require('@sequelize/core');
-const {expect} = require("chai");
+const { expect } = require('chai');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
   describe('method findByPk', () => {
@@ -51,7 +51,9 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       const findOneSpy = sinon.spy(Sequelize.Model, 'findOne');
 
       await Model.findByPk({ pk1: 1, pk2: 2 });
-      findOneSpy.should.have.been.calledWithMatch({  where: { pk1: 1, pk2: 2 } });
+      findOneSpy.should.have.been.calledWithMatch({
+        where: { pk1: 1, pk2: 2 },
+      });
     });
 
     it('should throw error if composite primary key args not match key', async () => {
@@ -66,7 +68,9 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         },
       });
 
-      expect(Model.findByPk({ pk1: 1 })).to.eventually.be.rejectedWith(TypeError);
+      expect(Model.findByPk({ pk1: 1 })).to.eventually.be.rejectedWith(
+        TypeError,
+      );
     });
   });
 });

--- a/packages/core/test/unit/model/find-by-pk.test.js
+++ b/packages/core/test/unit/model/find-by-pk.test.js
@@ -47,7 +47,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         },
       });
 
-      Model.findOne = sinon.stub();
+      sinon.stub(Model, 'findOne');
       const findOneSpy = sinon.spy(Sequelize.Model, 'findOne');
 
       await Model.findByPk({ pk1: 1, pk2: 2 });

--- a/packages/core/test/unit/model/find-by-pk.test.js
+++ b/packages/core/test/unit/model/find-by-pk.test.js
@@ -5,6 +5,7 @@ const Support = require('../../support');
 const current = Support.sequelize;
 const sinon = require('sinon');
 const { DataTypes, Sequelize } = require('@sequelize/core');
+const {expect} = require("chai");
 
 describe(Support.getTestDialectTeaser('Model'), () => {
   describe('method findByPk', () => {
@@ -32,6 +33,40 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       await Model.findByPk(1);
       Model.findOne.should.not.have.been.called;
       Sequelize.Model.findOne.should.have.been.called;
+    });
+
+    it('should use composite primary key when querying table has one', async () => {
+      const Model = current.define('model', {
+        pk1: {
+          type: DataTypes.INTEGER,
+          primaryKey: true,
+        },
+        pk2: {
+          type: DataTypes.INTEGER,
+          primaryKey: true,
+        },
+      });
+
+      Model.findOne = sinon.stub();
+      const findOneSpy = sinon.spy(Sequelize.Model, 'findOne');
+
+      await Model.findByPk({ pk1: 1, pk2: 2 });
+      findOneSpy.should.have.been.calledWithMatch({  where: { pk1: 1, pk2: 2 } });
+    });
+
+    it('should throw error if composite primary key args not match key', async () => {
+      const Model = current.define('model', {
+        pk1: {
+          type: DataTypes.INTEGER,
+          primaryKey: true,
+        },
+        pk2: {
+          type: DataTypes.INTEGER,
+          primaryKey: true,
+        },
+      });
+
+      expect(Model.findByPk({ pk1: 1 })).to.eventually.be.rejectedWith(TypeError);
     });
   });
 });


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

Add support for `findByPk` for composite keys by using objects and passing the keys

## Todos

- [ ] <!-- e.g. #1 feature: Extend the type script definition -->
- [ ] <!-- e.g. #2 test: Does this also work with MySQL 8? -->
- [ ] <!-- ... -->
