### PR TITLE
fix/associations-and-as-alias-created-duplicate-foreign-keys 

### DIFF
--- a/packages/core/src/model.js
+++ b/packages/core/src/model.js
@@ -1028,6 +1028,7 @@ ${associationOwner._getAssociationDebugList()}`);
         return association.associationType === 'BelongsTo';
       });
 
+    const createdForeignKeysFromAssociations = new Set();
     for (const association of associations) {
       const foreignKey = association.options.foreignKey;
       const sourceKeyFields = foreignKey.keys.map(k => k.sourceKey);
@@ -1037,7 +1038,10 @@ ${associationOwner._getAssociationDebugList()}`);
         ? `${tableName.tableName}_${sourceKeyFields.join('_')}_fkey`
         : `${tableName.tableName}_${sourceKeyFields.join('_')}_${association.target.modelDefinition.table.tableName}_${targetKeyFields.join('_')}_fkey`;
 
-      if (!existingConstraints.some(constraint => constraint.constraintName === constraintName)) {
+      if (
+        !existingConstraints.some(constraint => constraint.constraintName === constraintName) &&
+        !createdForeignKeysFromAssociations.has(constraintName)
+      ) {
         await this.queryInterface.addConstraint(tableName.tableName, {
           fields: sourceKeyFields,
           type: 'FOREIGN KEY',
@@ -1049,6 +1053,7 @@ ${associationOwner._getAssociationDebugList()}`);
           onDelete: foreignKey.onDelete,
           onUpdate: foreignKey.onUpdate,
         });
+        createdForeignKeysFromAssociations.add(constraintName);
       }
     }
 

--- a/packages/core/test/integration/model/sync.test.js
+++ b/packages/core/test/integration/model/sync.test.js
@@ -270,6 +270,38 @@ describe(getTestDialectTeaser('Model.sync & Sequelize#sync'), () => {
     expect(constraint).to.exist;
   });
 
+  it('should create composite foreign key constraint even if table has alias', async () => {
+    const User = sequelize.define('User', {
+      userId: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+      },
+      tenantId: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+      },
+      username: DataTypes.STRING,
+    });
+    const Address = sequelize.define('Address', {
+      addressId: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+      },
+    });
+    Address.belongsTo(User, { foreignKey: { keys: ['userId', 'tenantId'] }, as: 'SuperUser' });
+
+    await sequelize.sync({ alter: true });
+    await sequelize.sync({ alter: true });
+    const constraints = await sequelize.queryInterface.showConstraints(
+      Address.modelDefinition.table.tableName,
+    );
+    const constraint = constraints.find(
+      c =>
+        c.constraintType === 'FOREIGN KEY' && c.constraintName === 'Addresses_userId_tenantId_fkey',
+    );
+    expect(constraint).to.exist;
+  });
+
   it('should create composite foreign key constraint if table has no primary key but unique constraint exists', async () => {
     const User = sequelize.define(
       'User',


### PR DESCRIPTION
add fix for wanting to create duplicate foreign key when association has an alias

<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description of Changes

<!-- Please provide a description of the change here. -->

## List of Breaking Changes

<!-- If you have caused any breaking changes, you should list them below. -->
