### PR TITLE
fix(oracle): adapt bulk insert bind handling

### DIFF
--- a/packages/core/src/abstract-dialect/query-generator.d.ts
+++ b/packages/core/src/abstract-dialect/query-generator.d.ts
@@ -95,7 +95,7 @@ export class AbstractQueryGenerator<
     newEntries: object[],
     options?: BulkInsertOptions,
     columnDefinitions?: { [columnName: string]: NormalizedAttributeOptions },
-  ): string;
+  ): BoundQuery;
 
   addColumnQuery(
     table: TableName,

--- a/packages/core/test/unit/dialects/oracle/query-generator.test.js
+++ b/packages/core/test/unit/dialects/oracle/query-generator.test.js
@@ -5,7 +5,7 @@ const each = require('lodash/each');
 const chai = require('chai');
 
 const expect = chai.expect;
-const { DataTypes } = require('@sequelize/core');
+const { DataTypes, ParameterStyle } = require('@sequelize/core');
 const { OracleQueryGenerator: QueryGenerator } = require('@sequelize/oracle');
 const Support = require('../../../support');
 
@@ -501,8 +501,10 @@ if (dialect.startsWith('oracle')) {
       bulkInsertQuery: [
         {
           arguments: ['myTable', [{ name: 'foo' }, { name: 'bar' }], {}],
-          expectation: `INSERT INTO "myTable" ("name") VALUES (:1)`,
-          expectBind: [['foo'], ['bar']],
+          expectation: {
+            query: `INSERT INTO "myTable" ("name") VALUES (:1)`,
+            bind: [['foo'], ['bar']],
+          },
         },
         {
           arguments: [
@@ -514,8 +516,10 @@ if (dialect.startsWith('oracle')) {
             {},
             { id: { autoIncrement: true, type: integerDialect } },
           ],
-          expectation: `INSERT INTO "myTable" ("id","name") VALUES (DEFAULT,:1) RETURNING "id" INTO :2`,
-          expectBind: [['foo'], ['bar']],
+          expectation: {
+            query: `INSERT INTO "myTable" ("id","name") VALUES (DEFAULT,:1) RETURNING "id" INTO :2`,
+            bind: [['foo'], ['bar']],
+          },
           outBindAttributes: {
             id: {
               type: {
@@ -530,12 +534,24 @@ if (dialect.startsWith('oracle')) {
             },
           },
         },
+        {
+          arguments: [
+            'myTable',
+            [{ name: 'foo' }, { name: 'bar' }],
+            { parameterStyle: ParameterStyle.REPLACEMENT },
+          ],
+          expectation: new Error(
+            'The Oracle dialect does not support ParameterStyle.REPLACEMENT for bulk inserts.',
+          ),
+        },
 
         // Variants when quoteIdentifiers is false
         {
           arguments: ['myTable', [{ name: 'foo' }, { name: 'bar' }], {}],
-          expectation: `INSERT INTO myTable (name) VALUES (:1)`,
-          expectBind: [['foo'], ['bar']],
+          expectation: {
+            query: `INSERT INTO myTable (name) VALUES (:1)`,
+            bind: [['foo'], ['bar']],
+          },
           context: { options: { quoteIdentifiers: false } },
         },
         {
@@ -548,8 +564,10 @@ if (dialect.startsWith('oracle')) {
             {},
             { id: { autoIncrement: true, type: integerDialect } },
           ],
-          expectation: `INSERT INTO myTable (id,name) VALUES (DEFAULT,:1) RETURNING id INTO :2`,
-          expectBind: [['foo'], ['bar']],
+          expectation: {
+            query: `INSERT INTO myTable (id,name) VALUES (DEFAULT,:1) RETURNING id INTO :2`,
+            bind: [['foo'], ['bar']],
+          },
           outBindAttributes: {
             id: {
               type: {
@@ -745,15 +763,19 @@ if (dialect.startsWith('oracle')) {
               }
             }
 
-            const conditions = queryGenerator[suiteTitle](...test.arguments);
+            let conditions;
+
+            try {
+              conditions = queryGenerator[suiteTitle](...test.arguments);
+            } catch (error) {
+              conditions = error;
+            }
+
             expect(conditions).to.deep.equal(test.expectation);
-            if (test.expectBind) {
+            if (test.outBindAttributes && !(conditions instanceof Error)) {
               const args = test.arguments;
               const options = args[2];
-              expect(options.bind).to.deep.equal(test.expectBind);
-              if (test.outBindAttributes) {
-                expect(options.outBindAttributes).to.deep.equal(test.outBindAttributes);
-              }
+              expect(options.outBindAttributes).to.deep.equal(test.outBindAttributes);
             }
           });
         }

--- a/packages/core/test/unit/query-interface/bulk-insert.test.ts
+++ b/packages/core/test/unit/query-interface/bulk-insert.test.ts
@@ -44,6 +44,10 @@ describe('QueryInterface#bulkInsert', () => {
       // oracle uses `executeMany()` provided by node-oracledb driver and passes the value with binds
       oracle: toMatchRegex(/^INSERT INTO "Users" \("firstName"\) VALUES \(:\d+\)$/),
     });
+
+    if (sequelize.dialect.name === 'oracle') {
+      expect(stub.getCall(0).args[1]?.bind).to.deep.eq(users.map(user => [user.firstName]));
+    }
   });
 
   it('uses minimal insert queries when rows >1000', async () => {
@@ -69,6 +73,10 @@ describe('QueryInterface#bulkInsert', () => {
       ),
       oracle: toMatchRegex(/^INSERT INTO "Users" \("firstName"\) VALUES \(:\d+\)$/),
     });
+
+    if (sequelize.dialect.name === 'oracle') {
+      expect(stub.getCall(0).args[1]?.bind).to.deep.eq(users.map(user => [user.firstName]));
+    }
   });
 
   // you'll find more replacement tests in query-generator tests
@@ -105,5 +113,9 @@ describe('QueryInterface#bulkInsert', () => {
       ),
       oracle: toMatchSql(`INSERT INTO "Users" ("firstName") VALUES (:1)`),
     });
+
+    if (sequelize.dialect.name === 'oracle') {
+      expect(stub.getCall(0).args[1]?.bind).to.deep.eq([[':injection']]);
+    }
   });
 });

--- a/packages/oracle/src/query-generator.js
+++ b/packages/oracle/src/query-generator.js
@@ -9,7 +9,7 @@ import isPlainObject from 'lodash/isPlainObject';
 import toPath from 'lodash/toPath';
 import oracledb from 'oracledb';
 
-import { DataTypes } from '@sequelize/core';
+import { DataTypes, ParameterStyle } from '@sequelize/core';
 import { normalizeDataType } from '@sequelize/core/_non-semver-use-at-your-own-risk_/abstract-dialect/data-types-utils.js';
 import {
   ADD_COLUMN_QUERY_SUPPORTABLE_OPTIONS,
@@ -672,6 +672,13 @@ export class OracleQueryGenerator extends OracleQueryGeneratorTypeScript {
    */
   bulkInsertQuery(tableName, fieldValueHashes, options, fieldMappedAttributes) {
     options = options || {};
+
+    if (options.parameterStyle === ParameterStyle.REPLACEMENT) {
+      throw new Error(
+        'The Oracle dialect does not support ParameterStyle.REPLACEMENT for bulk inserts.',
+      );
+    }
+
     options.executeMany = true;
     fieldMappedAttributes = fieldMappedAttributes || {};
 
@@ -816,15 +823,13 @@ export class OracleQueryGenerator extends OracleQueryGeneratorTypeScript {
       ]);
     }
 
-    // Binding the bind variable to result
-    const result = query;
-    // Binding the bindParam to result
-    // Tuple has each row for the insert query
-    options.bind = tuples;
     // Setting options.inbindAttribute
     options.inbindAttributes = inBindBindDefMap;
 
-    return result;
+    return {
+      query,
+      bind: tuples,
+    };
   }
 
   deleteQuery(tableName, where, options = EMPTY_OBJECT, model) {

--- a/packages/oracle/src/query-interface.js
+++ b/packages/oracle/src/query-interface.js
@@ -6,6 +6,29 @@ import intersection from 'lodash/intersection.js';
 import uniq from 'lodash/uniq.js';
 
 export class OracleQueryInterface extends AbstractQueryInterface {
+  async bulkInsert(tableName, records, options, attributes) {
+    if (options?.bind) {
+      assertNoReservedBind(options.bind);
+    }
+
+    options = { ...options, type: QueryTypes.INSERT };
+
+    const { bind, query } = this.queryGenerator.bulkInsertQuery(
+      tableName,
+      records,
+      options,
+      attributes,
+    );
+
+    // unlike bind, replacements are handled by QueryGenerator, not QueryRaw
+    delete options.replacements;
+    options.bind = bind;
+
+    const results = await this.sequelize.queryRaw(query, options);
+
+    return results[0];
+  }
+
   async upsert(tableName, insertValues, updateValues, where, options) {
     if (options.bind) {
       assertNoReservedBind(options.bind);


### PR DESCRIPTION
## Summary
- update Oracle bulk inserts to return `{ query, bind }` while preserving the `executeMany()` bind matrix and metadata
- add an Oracle `QueryInterface#bulkInsert` override so bulk inserts bypass the generic bind merge path
- reject `ParameterStyle.REPLACEMENT` for Oracle bulk inserts and add test coverage for the new contract

## Testing
- `DIALECT=oracle yarn --cwd packages/core mocha \"test/unit/dialects/oracle/query-generator.test.js\"`
- `DIALECT=oracle yarn --cwd packages/core mocha \"test/unit/query-interface/bulk-insert.test.ts\"`